### PR TITLE
Chore/preset changes

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -20,8 +20,10 @@ const config = {
   presets: [
     [
       '@ionic-docs/preset-classic',
-      {
+      /** @type {import('@ionic-docs/preset-classic').Options} */
+      ({
         docs: {
+          breadcrumbs: false,
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/ionic-team/superapp-starter/tree/main/website/',
@@ -30,7 +32,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      },
+        googleTagManager: {
+          containerId: 'GTM-TKMGCBC',
+        },
+      }),
     ],
   ],
   themeConfig:
@@ -102,9 +107,6 @@ const config = {
       },
       colorMode: {
         respectPrefersColorScheme: true,
-      },
-      tagManager: {
-        trackingID: 'GTM-TKMGCBC',
       },
     }),
 };

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^2.4.3",
-        "@ionic-docs/preset-classic": "0.0.19",
+        "@ionic-docs/preset-classic": "0.0.23",
         "@ionic/prettier-config": "^2.0.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@ionic-docs/preset-classic": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@ionic-docs/preset-classic/-/preset-classic-0.0.19.tgz",
-      "integrity": "sha512-2nMlRNaLQK54Jcj6lJabChRKWlqgTxRIz1OdHgsRGTXXnJDwhKX0ctWLAdcrNjdt/rwh0K9jhOmmfr04H9NVbg==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@ionic-docs/preset-classic/-/preset-classic-0.0.23.tgz",
+      "integrity": "sha512-iBUIUTblSOgWj51C3xKPuih0FuEcT02lN1cHHm1oM8blLhY8QxphIgebvPvVKLFmc3v3lDrzQ4S4MtameoidXg==",
       "dependencies": {
         "@csstools/postcss-cascade-layers": "^2.0.0",
         "@docusaurus/core": "^2.4.3",
@@ -2648,7 +2648,7 @@
         "@docusaurus/theme-common": "^2.4.3",
         "@docusaurus/theme-search-algolia": "^2.4.3",
         "@docusaurus/types": "^2.4.3",
-        "@ionic-docs/theme-classic": "^0.0.17",
+        "@ionic-docs/theme-classic": "^0.0.19",
         "@ionic-internal/design-system": "^0.0.1",
         "docusaurus-plugin-sass": "^0.2.5",
         "postcss-import": "^15.1.0",
@@ -2663,9 +2663,9 @@
       }
     },
     "node_modules/@ionic-docs/theme-classic": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@ionic-docs/theme-classic/-/theme-classic-0.0.17.tgz",
-      "integrity": "sha512-as9xBHYBUtpog32hQk56GepAfgo7CAWA0p63gwbxnvQ9J1e4d//i3ZCERNA8JTaiPk/+fVsCV15VdQyawCBOdQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@ionic-docs/theme-classic/-/theme-classic-0.0.19.tgz",
+      "integrity": "sha512-nl3/9WndNQszEpbrNpQ2X+dp9jDju4GL9AfbJUKSwlvfWlCEOMO04Af3uxzoGoICmRbD+NYTs4WGyNMl57+9Uw==",
       "dependencies": {
         "@docusaurus/theme-common": "^2.4.3",
         "@ionic-internal/design-system": "^0.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@docusaurus/core": "^2.4.3",
     "@ionic/prettier-config": "^2.0.0",
-    "@ionic-docs/preset-classic": "0.0.19",
+    "@ionic-docs/preset-classic": "0.0.23",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.1",


### PR DESCRIPTION
This PR:
- bumps `@ionic-docs/preset-classic` package to latest
- updates config to hide breadcrumbs, allow analytics, and be more strongly typed